### PR TITLE
Updated gathercontent-downloadfiles

### DIFF
--- a/tasks/gathercontent.js
+++ b/tasks/gathercontent.js
@@ -271,20 +271,30 @@ module.exports = function (grunt) {
 
   grunt.registerTask('gathercontent-downloadfiles', 'download files', function () {
       var done= this.async(),
-          dest = config.fileDest; 
+          dest = config.fileDest;
+      var files = grunt.file.readJSON(config.jsonDest + "/files.json");
       if(config.downloadFiles)
       {
         if (!fs.existsSync(config.fileDest) && !config.pageDir)
             fs.mkdirSync(config.fileDest);
         var i = 0;
+        var completed = 0;
         async.eachSeries(
           files,
-          function (item,done)
+          function (item,cb)
           {
             grunt.log.write('Downloading',item.original_filename+'\n');
             var _requestFile = function (dest)
             {
-              request('https://gathercontent.s3.amazonaws.com/'+item.filename).pipe(fs.createWriteStream(dest+'/'+item.original_filename))
+                var file = fs.createWriteStream(dest+'/'+item.original_filename);
+                request('https://gathercontent.s3.amazonaws.com/'+item.filename, function(error, response, body){
+                        completed++;
+                    grunt.log.success('Downloaded '+item.original_filename+'\n');
+                    if(i === completed) {
+                        grunt.log.success('Completed Downloading '+completed+' files');
+                        done();
+                    }
+                }).pipe(file);
             }
             if(config.pageDir)
             {
@@ -299,12 +309,12 @@ module.exports = function (grunt) {
             else
             {
               _requestFile(dest);
-            }  
+            }
             i++;
-            done();
+            cb();
           },
           function (err){
-            grunt.log.success('Downloaded '+i+' files');
+                
           }
         );
       }


### PR DESCRIPTION
This fix ensures that all the files have downloaded before the task is allowed to complete. Tasks that depend on the downloaded files can be certain the files are there. 

Changes:
- Read the list of files from the local files.json.
- change the name of the callback from `done();`, to `cb();` so that it doesn't.
- override the async `done();`.
- Add a callback function to the request that each file will call it once it has finished downloading.
- After each file has downloaded, compare the current download length to the number of requests made. When equal, call `done();` to complete the task.
